### PR TITLE
src/Makefile: Allow to modify CFLAGS & LDFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,12 +7,12 @@ $(shell mkdir -p $(DEPDIR) >/dev/null)
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 
 CC	= gcc
-CFLAGS	= -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 \
+CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 \
 	  -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
 	  -fPIE -fexceptions -I../../libmtdac/include \
 	  -DGIT_VERSION=${GIT_VERSION} -pipe
-LDFLAGS = -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
-LIBS	= -lmtdac
+LDFLAGS += -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
+LIBS	 = -lmtdac
 POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
 
 GCC_MAJOR	:= $(shell gcc -dumpfullversion -dumpversion | cut -d . -f 1)


### PR DESCRIPTION
Sometimes it may be required to update these variable, e.g to add
extra library and include search paths.

This will be needed for running mtd-cli through the LGTM[0] service
where we will need to specify the location of the libmtdac libraries /
headers.

[0]: https://lgtm.com/

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>