### PR TITLE
Enable FreeBSD build test on cirrus-ci.org

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,25 @@
+freebsd_instance:
+  image_family: freebsd-13-0
+  cpu: 1
+  memory: 1G
+
+task:
+  name: freebsd_13 (clang)
+  skip: "!changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
+  install_script: pkg install -y git gmake jansson curl e2fsprogs-libuuid
+  clone_script: |
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
+  script: |
+    git clone https://github.com/ac000/libmtdac.git ${CIRRUS_WORKING_DIR}/libmtdac
+    cd ${CIRRUS_WORKING_DIR}/libmtdac/src
+    gmake CC=clang
+    export LD_LIBRARY_PATH=`pwd`
+    cd -
+    CFLAGS="-I${CIRRUS_WORKING_DIR}/libmtdac/include -Werror" LDFLAGS=-L${CIRRUS_WORKING_DIR}/libmtdac/src gmake CC=clang V=1


### PR DESCRIPTION
This runs in a FreeBSD 13.0 VM and uses clang.

It should only trigger on updates to; Makefile, src/ & .cirrus.yml

It adds -Werror to the CFLAGS to try and keep a warning free build.