### PR TITLE
Makefile updates and a build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS = mtd-cli
+TARGETS = mtd-cli hdrchk
 
 .PHONY: all $(TARGETS)
 all: $(TARGETS)
@@ -9,6 +9,11 @@ MAKE_OPTS = --no-print-directory V=$V
 mtd-cli:
 	@echo -e "Building: mtd-cli"
 	@$(MAKE) $(MAKE_OPTS) -C src/
+
+.PHONY: hdrchk
+hdrchk:
+	@echo -e "Checking Headers"
+	@$(MAKE) $(MAKE_OPTS) -C src/ hdrchk
 
 .PHONY: clean
 clean:

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 .d/
 
 *.o
+*.gch
 
 mtd-cli

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ GIT_VERSION = \"$(shell git describe --always --long --dirty --all)\"
 
 DEPDIR  := .d
 $(shell mkdir -p $(DEPDIR) >/dev/null)
-DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
+DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).Td
 
 CC	= gcc
 CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 \
@@ -13,7 +13,7 @@ CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 \
 	  -DGIT_VERSION=${GIT_VERSION} -pipe
 LDFLAGS += -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
 LIBS	 = -lmtdac
-POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
+POSTCOMPILE = @mv -f $(DEPDIR)/$(@F).Td $(DEPDIR)/$(@F).d && touch $@
 
 ifeq ($(CC),gcc)
         GCC_MAJOR  := $(shell gcc -dumpfullversion -dumpversion | cut -d . -f 1)
@@ -28,7 +28,7 @@ ifeq ($(CC),gcc)
         endif
 endif
 
-sources     = $(wildcard *.c)
+sources = $(wildcard *.c)
 objects = $(sources:.c=.o)
 
 ifeq ($(ASAN),1)
@@ -48,18 +48,29 @@ $(APPNAME): $(objects)
 	$(v)$(CC) $(LDFLAGS) $(ASAN) -o $@ $(objects) $(LIBS)
 
 %.o: %.c
-%.o: %.c $(DEPDIR)/%.d
+%.o: %.c $(DEPDIR)/%.o.d
 	@echo -e "  CC\t$@"
+	$(v)$(CC) $(DEPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(POSTCOMPILE)
+
+headers := $(wildcard *.h)
+hdrobjs := $(headers:.h=.gch)
+
+hdrchk: $(hdrobjs)
+%.gch: %.h
+%.gch: %.h $(DEPDIR)/%.gch.d
+	@echo -e "  CC\t$<"
 	$(v)$(CC) $(DEPFLAGS) $(CFLAGS) -c -o $@ $<
 	$(POSTCOMPILE)
 
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d
 
-include $(wildcard $(patsubst %,$(DEPDIR)/%.d,$(basename $(sources))))
+include $(wildcard $(patsubst %,$(DEPDIR)/%.o.d,$(basename $(sources))))
+include $(wildcard $(patsubst %,$(DEPDIR)/%.gch.d,$(basename $(headers))))
 
 .PHONY: clean
 clean:
-	$(v)rm -f $(objects) $(APPNAME)
+	$(v)rm -f $(objects) $(hdrobjs) $(APPNAME)
 	$(v)rm -f $(DEPDIR)/*
-	$(v)rmdir $(DEPDIR)
+	$(v)@rmdir $(DEPDIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,9 +7,10 @@ $(shell mkdir -p $(DEPDIR) >/dev/null)
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).Td
 
 CC	= gcc
-CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 \
-	  -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
-	  -fPIE -fexceptions -I../../libmtdac/include \
+CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla \
+	  -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition \
+	  -std=gnu99 -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
+	  -fno-common -fPIE -fexceptions -I../../libmtdac/include \
 	  -DGIT_VERSION=${GIT_VERSION} -pipe
 LDFLAGS += -L../../libmtdac/src -Wl,-z,now,-z,defs,-z,relro,--as-needed -pie
 LIBS	 = -lmtdac

--- a/src/mtd-cli.c
+++ b/src/mtd-cli.c
@@ -115,8 +115,8 @@ static char *gen_query_string(const char *src, char *dst, size_t len)
 	return ptr;
 }
 
-int check_args(int argc, char *argv[], const char *api,
-	       const struct _endpoint *ep)
+static int check_args(int argc, char *argv[], const char *api,
+		      const struct _endpoint *ep)
 {
 	int i = 0;
 	const char *name = argv[0];
@@ -144,7 +144,8 @@ out_help:
 	return -ERR_IGNORE;
 }
 
-int do_api_func(const struct endpoint *ep, int argc, char *argv[], char **buf)
+static int do_api_func(const struct endpoint *ep, int argc, char *argv[],
+		       char **buf)
 {
 	int i;
 	const char *args[MAX_ARGV] = { NULL };


### PR DESCRIPTION
The first commit adds a 'hdrchk' target to the Makefile. This will build each header individually to check that they are self-contained and contain everything they need.

The second commit marks a couple of functions as 'static' in mtd-cli.c to fix a couple of 'warning: no previous prototype for ...' messages.

The third commit adds some extra compiler flags; -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition -fno-common, to help enforce coding style and correctness.