### PR TITLE
mtd-cli.h: Make the union of function pointers anonymous

### DIFF
--- a/src/mtd-cli-bd.c
+++ b/src/mtd-cli-bd.c
@@ -20,17 +20,13 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "list",
-		.api_func = {
-			.func_0 = mtd_bd_list
-		},
+		.func_0 = mtd_bd_list,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "get",
-		.api_func = {
-			.func_1 = mtd_bd_get
-		},
+		.func_1 = mtd_bd_get,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "businessId"

--- a/src/mtd-cli-biss.c
+++ b/src/mtd-cli-biss.c
@@ -20,25 +20,19 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "get-self-employment",
-		.api_func = {
-			.func_1 = mtd_biss_get_self_employment
-		},
+		.func_1 = mtd_biss_get_self_employment,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "selfEmploymentId=[,taxYear=YYYY-YY]"
 	}, {
 		.name = "get-uk-property",
-		.api_func = {
-			.func_1 = mtd_biss_get_uk_property
-		},
+		.func_1 = mtd_biss_get_uk_property,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "typeOfBusiness={uk-property-non-fhl,uk-property-fhl}[,taxYear=YYYY-YY]"
 	}, {
 		.name = "get-foreign-property",
-		.api_func = {
-			.func_1 = mtd_biss_get_foreign_property
-		},
+		.func_1 = mtd_biss_get_foreign_property,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "businessId=,typeOfBusiness={foreign-property-fhl-eea,foreign-property}[,taxYear=YYYY-YY]"

--- a/src/mtd-cli-bsas.c
+++ b/src/mtd-cli-bsas.c
@@ -27,89 +27,67 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "list-summaries",
-		.api_func = {
-			.func_1 = mtd_bsas_list_summaries
-		},
+		.func_1 = mtd_bsas_list_summaries,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[[selfEmploymentId=][,[typeOfBusiness={self-employment,uk-property-non-fhl,uk-property-fhl}][,[taxYear=YYYY-YY]]]]"
 	}, {
 		.name = "trigger-summary",
-		.api_func = {
-			.func_1d = mtd_bsas_trigger_summary
-		},
+		.func_1d = mtd_bsas_trigger_summary,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "se-get-summary",
-		.api_func = {
-			.func_2 = mtd_bsas_se_get_summary
-		},
+		.func_2 = mtd_bsas_se_get_summary,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "bsasId [adjustedStatus={true,false}]"
 	}, {
 		.name = "se-list-summary-adjustments",
-		.api_func = {
-			.func_1 = mtd_bsas_se_list_summary_adjustments
-		},
+		.func_1 = mtd_bsas_se_list_summary_adjustments,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "bsasId"
 	}, {
 		.name = "se-update-summary-adjustments",
-		.api_func = {
-			.func_2d = mtd_bsas_se_update_summary_adjustments
-		},
+		.func_2d = mtd_bsas_se_update_summary_adjustments,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> bsasId"
 	}, {
 		.name = "pb-get-summary",
-		.api_func = {
-			.func_2 = mtd_bsas_pb_get_summary
-		},
+		.func_2 = mtd_bsas_pb_get_summary,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "bsasId [adjustedStatus={true,false}]"
 	}, {
 		.name = "pb-list-summary-adjustments",
-		.api_func = {
-			.func_1 = mtd_bsas_pb_list_summary_adjustments
-		},
+		.func_1 = mtd_bsas_pb_list_summary_adjustments,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "bsasId"
 	}, {
 		.name = "pb-update-summary-adjustments",
-		.api_func = {
-			.func_2d = mtd_bsas_pb_update_summary_adjustments
-		},
+		.func_2d = mtd_bsas_pb_update_summary_adjustments,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> bsasId"
 	}, {
 		.name = "fp-get-summary",
-		.api_func = {
-			.func_2 = mtd_bsas_fp_get_summary
-		},
+		.func_2 = mtd_bsas_fp_get_summary,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "bsasId [adjustedStatus={true,false}]"
 	}, {
 		.name = "fp-list-summary-adjustments",
-		.api_func = {
-			.func_1 = mtd_bsas_fp_list_summary_adjustments
-		},
+		.func_1 = mtd_bsas_fp_list_summary_adjustments,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "bsasId"
 	}, {
 		.name = "fp-update-summary-adjustments",
-		.api_func = {
-			.func_2d = mtd_bsas_fp_update_summary_adjustments
-		},
+		.func_2d = mtd_bsas_fp_update_summary_adjustments,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> bsasId"

--- a/src/mtd-cli-ibeops.c
+++ b/src/mtd-cli-ibeops.c
@@ -20,9 +20,7 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "submit-end-of-period-statement",
-		.api_func = {
-			.func_1d = mtd_ibeops_submit_eops
-		},
+		.func_1d = mtd_ibeops_submit_eops,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"

--- a/src/mtd-cli-ic.c
+++ b/src/mtd-cli-ic.c
@@ -28,81 +28,61 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "sa-list-calculations",
-		.api_func = {
-			.func_1 = mtd_ic_sa_list_calculations
-		},
+		.func_1 = mtd_ic_sa_list_calculations,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[taxYear=YYYY-YY]"
 	}, {
 		.name = "sa-trigger-calculation",
-		.api_func = {
-			.func_1d = mtd_ic_sa_trigger_calculation
-		},
+		.func_1d = mtd_ic_sa_trigger_calculation,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "sa-get-calculation-metadata",
-		.api_func = {
-			.func_1 = mtd_ic_sa_get_calculation_meta
-		},
+		.func_1 = mtd_ic_sa_get_calculation_meta,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "calculationId"
 	}, {
 		.name = "sa-get-income-tax-nics-calc",
-		.api_func = {
-			.func_1 = mtd_ic_sa_get_income_tax_nics_calc
-		},
+		.func_1 = mtd_ic_sa_get_income_tax_nics_calc,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "calculationId"
 	}, {
 		.name = "sa-get-taxable-income",
-		.api_func = {
-			.func_1 = mtd_ic_sa_get_taxable_income
-		},
+		.func_1 = mtd_ic_sa_get_taxable_income,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "calculationId"
 	}, {
 		.name = "sa-get-allowances-deductions-reliefs",
-		.api_func = {
-			.func_1 = mtd_ic_sa_get_allowances_deductions_reliefs
-		},
+		.func_1 = mtd_ic_sa_get_allowances_deductions_reliefs,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "calculationId"
 	}, {
 		.name = "sa-get-end-of-year-estimate",
-		.api_func = {
-			.func_1 = mtd_ic_sa_get_end_of_year_est
-		},
+		.func_1 = mtd_ic_sa_get_end_of_year_est,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "calculationId"
 	}, {
 		.name = "sa-get-messages",
-		.api_func = {
-			.func_2 = mtd_ic_sa_get_messages
-		},
+		.func_2 = mtd_ic_sa_get_messages,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "calculationId [[type={info,warning,error}], ...]"
 	}, {
 		.name = "cr-intent-to-crystallise",
-		.api_func = {
-			.func_1 = mtd_ic_cr_intent_to_crystallise
-		},
+		.func_1 = mtd_ic_cr_intent_to_crystallise,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "cr-crystallise",
-		.api_func = {
-			.func_2d = mtd_ic_cr_crystallise
-		},
+		.func_2d = mtd_ic_cr_crystallise,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"

--- a/src/mtd-cli-id.c
+++ b/src/mtd-cli-id.c
@@ -23,25 +23,19 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "get",
-		.api_func = {
-			.func_1 = mtd_id_get
-		},
+		.func_1 = mtd_id_get,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "set",
-		.api_func = {
-			.func_2d = mtd_id_set
-		},
+		.func_2d = mtd_id_set,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> teaxYear"
 	}, {
 		.name = "delete",
-		.api_func = {
-			.func_1 = mtd_id_delete
-		},
+		.func_1 = mtd_id_delete,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
@@ -49,9 +43,7 @@ static const struct endpoint endpoints[] = {
 	/* Marriage Allowance */
 	{
 		.name = "ma-create",
-		.api_func = {
-			.func_1d = mtd_id_ma_create
-		},
+		.func_1d = mtd_id_ma_create,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"

--- a/src/mtd-cli-il.c
+++ b/src/mtd-cli-il.c
@@ -26,41 +26,31 @@ static const struct endpoint endpoints[] = {
 	/* Brought Forward Loses */
 	{
 		.name = "bf-list-loses",
-		.api_func = {
-			.func_1 = mtd_il_bf_list_loses
-		},
+		.func_1 = mtd_il_bf_list_loses,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[[businessId=][,[taxYear=YYYY-YY][,[typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}]]]]"
 	}, {
 		.name = "bf-create-loss",
-		.api_func = {
-			.func_1d = mtd_il_bf_create_loss
-		},
+		.func_1d = mtd_il_bf_create_loss,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "bf-get-loss",
-		.api_func = {
-			.func_1 = mtd_il_bf_get_loss
-		},
+		.func_1 = mtd_il_bf_get_loss,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "lossId"
 	}, {
 		.name = "bf-delete-loss",
-		.api_func = {
-			.func_1 = mtd_il_bf_delete_loss
-		},
+		.func_1 = mtd_il_bf_delete_loss,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "lossId"
 	}, {
 		.name = "bf-update-loss-amnt",
-		.api_func = {
-			.func_2d = mtd_il_bf_update_loss_amnt
-		},
+		.func_2d = mtd_il_bf_update_loss_amnt,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> lossaId"
@@ -68,50 +58,38 @@ static const struct endpoint endpoints[] = {
 	/* Loss Claims */
 	{
 		.name = "lc-list-loses",
-		.api_func = {
-			.func_1 = mtd_il_lc_list_loses
-		},
+		.func_1 = mtd_il_lc_list_loses,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[[businessId=][,[taxYear=YYYY-YY][,[typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}][,[claimType=carry-sideways]]]]]"
 	}, {
 		.name = "lc-create-loss",
-		.api_func = {
-			.func_1d = mtd_il_lc_create_loss
-		},
+		.func_1d = mtd_il_lc_create_loss,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "lc-get-loss",
-		.api_func = {
-			.func_1 = mtd_il_lc_get_loss
-		},
+		.func_1 = mtd_il_lc_get_loss,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "claimId"
 	}, {
 		.name = "lc-delete-loss",
-		.api_func = {
-			.func_1 = mtd_il_lc_delete_loss
-		},
+		.func_1 = mtd_il_lc_delete_loss,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "claimId"
 	}, {
 		.name = "lc-update-loss-type",
-		.api_func = {
-			.func_2d = mtd_il_lc_update_loss_type
-		},
+		.func_2d = mtd_il_lc_update_loss_type,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> claimId"
 	},
 	{
 		.name = "lc-update-loss-order",
-		.api_func = {
-			.func_2d = mtd_il_lc_update_loss_order
-		},
+		.func_2d = mtd_il_lc_update_loss_order,
 		.func = FUNC_2d,
 		.nr_req_args = 1,
 		.args = "<file> [taxYear=YYYY-YY]"

--- a/src/mtd-cli-ob.c
+++ b/src/mtd-cli-ob.c
@@ -22,25 +22,19 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "list-inc-and-exp-obligations",
-		.api_func = {
-			.func_1 = mtd_ob_list_inc_and_expend_obligations
-		},
+		.func_1 = mtd_ob_list_inc_and_expend_obligations,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[[[typeOfBusiness={self-employment,uk-property,foreign-property}][,businessId=]][,[fromDate=YYYY-MM-DD,toDate=YYYY-MM-DD]][,[status={Open,Fulfilled}]]]"
 	}, {
 		.name = "list-crystallisation-obligations",
-		.api_func = {
-			.func_1 = mtd_ob_list_crystallisation_obligations
-		},
+		.func_1 = mtd_ob_list_crystallisation_obligations,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[taxYear=YYYY-MM]"
 	}, {
 		.name = "list-end-of-period-obligations",
-		.api_func = {
-			.func_1 = mtd_ob_list_end_of_period_obligations
-		},
+		.func_1 = mtd_ob_list_end_of_period_obligations,
 		.func = FUNC_1,
 		.nr_req_args = 0,
 		.args = "[[[typeOfBusiness={self-employment,uk-property,foreign-property}][,businessId=]][,[fromDate=YYYY-MM-DD,toDate=YYYY-MM-DD]][,[status={Open,Fulfilled}]]]"

--- a/src/mtd-cli-sa.c
+++ b/src/mtd-cli-sa.c
@@ -38,57 +38,43 @@ static const struct endpoint endpoints[] = {
 	/* Self-Employment */
 	{
 		.name = "se-create-employment",
-		.api_func = {
-			.func_1d = mtd_sa_se_create_employment
-		},
+		.func_1d = mtd_sa_se_create_employment,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "se-list-periods",
-		.api_func = {
-			.func_1 = mtd_sa_se_list_periods
-		},
+		.func_1 = mtd_sa_se_list_periods,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "selfEmploymentId"
 	}, {
 		.name = "se-create-period",
-		.api_func = {
-			.func_2d = mtd_sa_se_create_period
-		},
+		.func_2d = mtd_sa_se_create_period,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> selfEmploymentId"
 	}, {
 		.name = "se-get-period",
-		.api_func = {
-			.func_2 = mtd_sa_se_get_period
-		},
+		.func_2 = mtd_sa_se_get_period,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "selfEmploymentId periodId"
 	}, {
 		.name = "se-update-period",
-		.api_func = {
-			.func_3d = mtd_sa_se_update_period
-		},
+		.func_3d = mtd_sa_se_update_period,
 		.func = FUNC_3d,
 		.nr_req_args = 3,
 		.args = "<file> selfEmploymentId periodId"
 	}, {
 		.name = "se-get-annual-summary",
-		.api_func = {
-			.func_2 = mtd_sa_se_get_annual_summary
-		},
+		.func_2 = mtd_sa_se_get_annual_summary,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "selfEmploymentId taxYear"
 	}, {
 		.name = "se-update-annual-summary",
-		.api_func = {
-			.func_3d = mtd_sa_se_update_annual_summary
-		},
+		.func_3d = mtd_sa_se_update_annual_summary,
 		.func = FUNC_3d,
 		.nr_req_args = 3,
 		.args = "<file> selfEmploymentId taxYear"
@@ -96,104 +82,78 @@ static const struct endpoint endpoints[] = {
 	/* Self-Assessment - UK Property Business */
 	{
 		.name = "pb-create-property",
-		.api_func = {
-			.func_1d = mtd_sa_pb_create_property
-		},
+		.func_1d = mtd_sa_pb_create_property,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "pb-list-non-fhl-periods",
-		.api_func = {
-			.func_0 = mtd_sa_pb_list_non_fhl_periods
-		},
+		.func_0 = mtd_sa_pb_list_non_fhl_periods,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "pb-create-non-fhl-period",
-		.api_func = {
-			.func_1d = mtd_sa_pb_create_non_fhl_period
-		},
+		.func_1d = mtd_sa_pb_create_non_fhl_period,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "pb-get-non-fhl-period",
-		.api_func = {
-			.func_1 = mtd_sa_pb_get_non_fhl_period
-		},
+		.func_1 = mtd_sa_pb_get_non_fhl_period,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "periodId"
 	}, {
 		.name = "pb-update-non-fhl-period",
-		.api_func = {
-			.func_2d = mtd_sa_pb_update_non_fhl_period
-		},
+		.func_2d = mtd_sa_pb_update_non_fhl_period,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> periodId"
 	}, {
 		.name = "pb-get-non-fhl-annual-summary",
-		.api_func = {
-			.func_1 = mtd_sa_pb_get_non_fhl_annual_summary
-		},
+		.func_1 = mtd_sa_pb_get_non_fhl_annual_summary,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "pb-update-non-fhl-annual-summary",
-		.api_func = {
-			.func_2d = mtd_sa_pb_update_non_fhl_annual_summary
-		},
+		.func_2d = mtd_sa_pb_update_non_fhl_annual_summary,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"
 	}, {
 		.name = "pb-list-fhl-periods",
-		.api_func = {
-			.func_0 = mtd_sa_pb_list_fhl_periods
-		},
+		.func_0 = mtd_sa_pb_list_fhl_periods,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "pb-create-fhl-period",
-		.api_func = {
-			.func_1d = mtd_sa_pb_create_fhl_period
-		},
+		.func_1d = mtd_sa_pb_create_fhl_period,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "pb-get-fhl-period",
-		.api_func = {
-			.func_1 = mtd_sa_pb_get_fhl_period
-		},
+		.func_1 = mtd_sa_pb_get_fhl_period,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "periodId"
 	}, {
 		.name = "pb-update-fhl-period",
-		.api_func = {
-			.func_2d = mtd_sa_pb_update_fhl_period
-		},
+		.func_2d = mtd_sa_pb_update_fhl_period,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> periodId"
 	}, {
 		.name = "pb-get-fhl-annual-summary",
-		.api_func = {
-			.func_1 = mtd_sa_pb_get_fhl_annual_summary
-		},
+		.func_1 = mtd_sa_pb_get_fhl_annual_summary,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "pb-update-fhl-annual-summary",
-		.api_func = {
-			.func_2d = mtd_sa_pb_update_fhl_annual_summary
-		},
+		.func_2d = mtd_sa_pb_update_fhl_annual_summary,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"
@@ -201,17 +161,13 @@ static const struct endpoint endpoints[] = {
 	/* Dividends Income */
 	{
 		.name = "di-get-annual-summary",
-		.api_func = {
-			.func_1 = mtd_sa_di_get_annual_summary
-		},
+		.func_1 = mtd_sa_di_get_annual_summary,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "di-update-annual-summary",
-		.api_func = {
-			.func_2d = mtd_sa_di_update_annual_summary
-		},
+		.func_2d = mtd_sa_di_update_annual_summary,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"
@@ -219,41 +175,31 @@ static const struct endpoint endpoints[] = {
 	/* Savings Accounts */
 	{
 		.name = "sa-list-accounts",
-		.api_func = {
-			.func_0 = mtd_sa_sa_list_accounts
-		},
+		.func_0 = mtd_sa_sa_list_accounts,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "sa-create-account",
-		.api_func = {
-			.func_1d = mtd_sa_sa_create_account
-		},
+		.func_1d = mtd_sa_sa_create_account,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "sa-get-account",
-		.api_func = {
-			.func_1 = mtd_sa_sa_get_account
-		},
+		.func_1 = mtd_sa_sa_get_account,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "savingsAccountId"
 	}, {
 		.name = "sa-get-annual-summary",
-		.api_func = {
-			.func_2 = mtd_sa_sa_get_annual_summary
-		},
+		.func_2 = mtd_sa_sa_get_annual_summary,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "savingsAccountId taxYear"
 	}, {
 		.name = "sa-update-annual-summary",
-		.api_func = {
-			.func_3d = mtd_sa_sa_update_annual_summary
-		},
+		.func_3d = mtd_sa_sa_update_annual_summary,
 		.func = FUNC_3d,
 		.nr_req_args = 3,
 		.args = "<file> savingsAccountId taxYear"
@@ -261,17 +207,13 @@ static const struct endpoint endpoints[] = {
 	/* Charitable Giving */
 	{
 		.name = "cg-get-charitable-giving",
-		.api_func = {
-			.func_1 = mtd_sa_cg_get_charitable_giving
-		},
+		.func_1 = mtd_sa_cg_get_charitable_giving,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "cg-update-charitable-giving",
-		.api_func = {
-			.func_2d = mtd_sa_cg_update_charitable_giving
-		},
+		.func_2d = mtd_sa_cg_update_charitable_giving,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"

--- a/src/mtd-cli-saac.c
+++ b/src/mtd-cli-saac.c
@@ -26,57 +26,43 @@ static const struct endpoint endpoints[] = {
 	/* Payments and Liabilities */
 	{
 		.name = "get-balance",
-		.api_func = {
-			.func_0 = mtd_saac_get_balance
-		},
+		.func_0 = mtd_saac_get_balance,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "list-transactions",
-		.api_func = {
-			.func_1 = mtd_saac_list_transactions
-		},
+		.func_1 = mtd_saac_list_transactions,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "from=YYYY-MM-DD,to=YYYY-MM-DD"
 	}, {
 		.name = "get-transaction",
-		.api_func = {
-			.func_1 = mtd_saac_get_transaction
-		},
+		.func_1 = mtd_saac_get_transaction,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "transactionId"
 	}, {
 		.name = "list-charges",
-		.api_func = {
-			.func_1 = mtd_saac_list_charges
-		},
+		.func_1 = mtd_saac_list_charges,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "from=YYYY-MM-DD,to=YYYY-MM-DD"
 	}, {
 		.name = "get-charge",
-		.api_func = {
-			.func_1 = mtd_saac_get_charge
-		},
+		.func_1 = mtd_saac_get_charge,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "transactionId"
 	}, {
 		.name = "list-payments",
-		.api_func = {
-			.func_1 = mtd_saac_list_payments
-		},
+		.func_1 = mtd_saac_list_payments,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "from=YYYY-MM-DD,to=YYYY-MM-DD"
 	}, {
 		.name = "get-payment",
-		.api_func = {
-			.func_1 = mtd_saac_get_payment
-		},
+			.func_1 = mtd_saac_get_payment,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "paymentId"
@@ -84,25 +70,19 @@ static const struct endpoint endpoints[] = {
 	/* Coding Out Underpayments and Debts */
 	{
 		.name = "co-get",
-		.api_func = {
-			.func_1 = mtd_saac_get_coding_out_uda
-		},
+		.func_1 = mtd_saac_get_coding_out_uda,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"
 	}, {
 		.name = "co-set",
-		.api_func = {
-			.func_2d = mtd_saac_set_coding_out_uda
-		},
+		.func_2d = mtd_saac_set_coding_out_uda,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> taxYear"
 	}, {
 		.name = "co-delete",
-		.api_func = {
-			.func_1 = mtd_saac_delete_coding_out_uda
-		},
+		.func_1 = mtd_saac_delete_coding_out_uda,
 		.func = FUNC_1,
 		.nr_req_args = 1,
 		.args = "taxYear"

--- a/src/mtd-cli-test-cu.c
+++ b/src/mtd-cli-test-cu.c
@@ -21,33 +21,25 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "create-individual",
-		.api_func = {
-			.func_1d = mtd_test_cu_create_individual
-		},
+		.func_1d = mtd_test_cu_create_individual,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "create-organisation",
-		.api_func = {
-			.func_1d = mtd_test_cu_create_organisation
-		},
+		.func_1d = mtd_test_cu_create_organisation,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "create-agent",
-		.api_func = {
-			.func_1d = mtd_test_cu_create_agent
-		},
+		.func_1d = mtd_test_cu_create_agent,
 		.func = FUNC_1d,
 		.nr_req_args = 1,
 		.args = "<file>"
 	}, {
 		.name = "list-services",
-		.api_func = {
-			.func_0 = mtd_test_cu_list_services
-		},
+		.func_0 = mtd_test_cu_list_services,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""

--- a/src/mtd-cli-test-fph.c
+++ b/src/mtd-cli-test-fph.c
@@ -21,17 +21,13 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "validate",
-		.api_func = {
-			.func_0 = mtd_test_fph_validate
-		},
+		.func_0 = mtd_test_fph_validate,
 		.func = FUNC_0,
 		.nr_req_args = 0,
 		.args = ""
 	}, {
 		.name = "feedback",
-		.api_func = {
-			.func_2 = mtd_test_fph_feedback
-		},
+		.func_2 = mtd_test_fph_feedback,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "api [connectionMethod=]"

--- a/src/mtd-cli-vat.c
+++ b/src/mtd-cli-vat.c
@@ -21,42 +21,32 @@
 static const struct endpoint endpoints[] = {
 	{
 		.name = "list-obligations",
-		.api_func = {
-			.func_2 = mtd_vat_list_obligations
-		},
+		.func_2 = mtd_vat_list_obligations,
 		.func = FUNC_2,
 		.nr_req_args = 1,
 		.args = "vrn [from=YYY-MM-DD][,[to=YYYY-MM-DD]][,[status=O|F]]"
 	}, {
 		.name = "submit-period",
-		.api_func = {
-			.func_2d = mtd_vat_submit_period
-		},
+		.func_2d = mtd_vat_submit_period,
 		.func = FUNC_2d,
 		.nr_req_args = 2,
 		.args = "<file> vrn"
 	},
 	{
 		.name = "get-period",
-		.api_func = {
-			.func_2 = mtd_vat_get_period
-		},
+		.func_2 = mtd_vat_get_period,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "vrn periodKey"
 	}, {
 		.name = "list-liabilities",
-		.api_func = {
-			.func_2 = mtd_vat_list_liabilities
-		},
+		.func_2 = mtd_vat_list_liabilities,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "vrn from=YYYY-MM-DD,to=YYYY-MM-DD"
 	}, {
 		.name = "list-payments",
-		.api_func = {
-			.func_2 = mtd_vat_list_payments
-		},
+		.func_2 = mtd_vat_list_payments,
 		.func = FUNC_2,
 		.nr_req_args = 2,
 		.args = "vrn from=YYYY-MM-DD,to=YYYY-MM-DD"

--- a/src/mtd-cli.c
+++ b/src/mtd-cli.c
@@ -184,21 +184,20 @@ static int do_api_func(const struct endpoint *ep, int argc, char *argv[],
 
 		switch (eps->func) {
 		case FUNC_0:
-			return eps->api_func.func_0(buf);
+			return eps->func_0(buf);
 		case FUNC_1:
-			return eps->api_func.func_1(args[0], buf);
+			return eps->func_1(args[0], buf);
 		case FUNC_1d:
-			return eps->api_func.func_1d(&dsctx, buf);
+			return eps->func_1d(&dsctx, buf);
 		case FUNC_2:
-			return eps->api_func.func_2(args[0], args[1], buf);
+			return eps->func_2(args[0], args[1], buf);
 		case FUNC_2d:
-			return eps->api_func.func_2d(&dsctx, args[1], buf);
+			return eps->func_2d(&dsctx, args[1], buf);
 		case FUNC_3d:
-			return eps->api_func.func_3d(&dsctx, args[1], args[2],
-						     buf);
+			return eps->func_3d(&dsctx, args[1], args[2], buf);
 		case FUNC_4d:
-			return eps->api_func.func_4d(&dsctx, args[1], args[2],
-						     args[3], buf);
+			return eps->func_4d(&dsctx, args[1], args[2], args[3],
+					    buf);
 		}
 	}
 

--- a/src/mtd-cli.h
+++ b/src/mtd-cli.h
@@ -76,7 +76,7 @@ struct endpoint {
 		int (*func_4d)(const struct mtd_dsrc_ctx *dsctx,
 			       const char *a2, const char *a3, const char *a4,
 			       char **buf);
-	} api_func;
+	};
 	const enum function_selector func;
 	const int nr_req_args;
 	const char *args;


### PR DESCRIPTION
In the endpoint structure there is a union of function pointers for the
various libmtdac functions.

Rather than giving this a name and accessing it like
endpoint.api_func.func_*, just make it anonymous and access the various
func_* members directly, e.g endpoint.func_*

Having the named union and the extra level of access doesn't really buy
us anything here and provides a nice cleanup in the various mtd-cli-*.c
files.

Anonymous unions are available as a GNU extension until they were
incorporated into the C11 standard, they also work in clang (when
building with -std=gnu99).
