### PR TITLE
mtd-cli-*.c: Remove stddef.h include

### DIFF
--- a/src/mtd-cli-bd.c
+++ b/src/mtd-cli-bd.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2021 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-bd.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-biss.c
+++ b/src/mtd-cli-biss.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-biss.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-bsas.c
+++ b/src/mtd-cli-bsas.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-bsas.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-ibeops.c
+++ b/src/mtd-cli-ibeops.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2021 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-ibeops.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-ic.c
+++ b/src/mtd-cli-ic.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-ic.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-id.c
+++ b/src/mtd-cli-id.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2021 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-id.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-il.c
+++ b/src/mtd-cli-il.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-il.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-ob.c
+++ b/src/mtd-cli-ob.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2021 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-ob.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-sa.c
+++ b/src/mtd-cli-sa.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-sa.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-saac.c
+++ b/src/mtd-cli-saac.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-saac.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-test-cu.c
+++ b/src/mtd-cli-test-cu.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-test-cu.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-test-fph.c
+++ b/src/mtd-cli-test-fph.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-test-fph.h>
 
 #include "mtd-cli.h"

--- a/src/mtd-cli-vat.c
+++ b/src/mtd-cli-vat.c
@@ -6,8 +6,6 @@
  * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
-#include <stddef.h>
-
 #include <libmtdac/mtd-vat.h>
 
 #include "mtd-cli.h"


### PR DESCRIPTION
Since commit 4075dc1 ("Use an empty terminating initialiser in the
endpoints[]") the stddef.h include is no longer needed as it was just
for the definition of 'NULL' which is no longer used.
