### PR TITLE
biss: Update for API version 2.0 changes

### DIFF
--- a/src/mtd-cli-biss.c
+++ b/src/mtd-cli-biss.c
@@ -13,27 +13,15 @@
 #define API	biss
 
 #define API_NAME "Business Income Source Summary"
-#define CMDS "get-self-employment get-uk-property get-foreign-property"
+#define CMDS "get-summary"
 
 static const struct endpoint endpoints[] = {
 	{
-		.name = "get-self-employment",
-		.func_1 = mtd_biss_get_self_employment,
-		.func = FUNC_1,
-		.nr_req_args = 1,
-		.args = "selfEmploymentId=[,taxYear=YYYY-YY]"
-	}, {
-		.name = "get-uk-property",
-		.func_1 = mtd_biss_get_uk_property,
-		.func = FUNC_1,
-		.nr_req_args = 1,
-		.args = "typeOfBusiness={uk-property-non-fhl,uk-property-fhl}[,taxYear=YYYY-YY]"
-	}, {
-		.name = "get-foreign-property",
-		.func_1 = mtd_biss_get_foreign_property,
-		.func = FUNC_1,
-		.nr_req_args = 1,
-		.args = "businessId=,typeOfBusiness={foreign-property-fhl-eea,foreign-property}[,taxYear=YYYY-YY]"
+		.name = "get-summary",
+		.func_3 = mtd_biss_get_summary,
+		.func = FUNC_3,
+		.nr_req_args = 3,
+		.args = "typeOfBusiness taxYear businessId"
 	},
 
 	{ }

--- a/src/mtd-cli.c
+++ b/src/mtd-cli.c
@@ -193,6 +193,8 @@ static int do_api_func(const struct endpoint *ep, int argc, char *argv[],
 			return eps->func_2(args[0], args[1], buf);
 		case FUNC_2d:
 			return eps->func_2d(&dsctx, args[1], buf);
+		case FUNC_3:
+			return eps->func_3(args[0], args[1], args[2], buf);
 		case FUNC_3d:
 			return eps->func_3d(&dsctx, args[1], args[2], buf);
 		case FUNC_4d:

--- a/src/mtd-cli.h
+++ b/src/mtd-cli.h
@@ -44,6 +44,7 @@ enum function_selector {
 	FUNC_1d,
 	FUNC_2,
 	FUNC_2d,
+	FUNC_3,
 	FUNC_3d,
 	FUNC_4d,
 };
@@ -71,6 +72,8 @@ struct endpoint {
 		int (*func_2)(const char *a1, const char *a2, char **buf);
 		int (*func_2d)(const struct mtd_dsrc_ctx *dsctx,
 			       const char *a2, char **buf);
+		int (*func_3)(const char *a1, const char *a2, const char *a3,
+			      char **buf);
 		int (*func_3d)(const struct mtd_dsrc_ctx *dsctx,
 			       const char *a2, const char *a3, char **buf);
 		int (*func_4d)(const struct mtd_dsrc_ctx *dsctx,


### PR DESCRIPTION
This comprises two commits that updates mtd-cli for the BISS API version 2.0 changes in libmtdac.

The first commit updates mtd-cli to handle libmtdac API functions that take 3 const char * arguments.
The second commit updates mtd-cli for the BISS API changes in libmtdac.