### PR TITLE
ci: Update OS's

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 freebsd_instance:
-  image_family: freebsd-13-0
+  image_family: freebsd-14-2
   cpu: 1
   memory: 1G
 
 task:
-  name: freebsd_13 (clang)
+  name: freebsd_14 (clang)
   skip: "!changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
   install_script: pkg install -y git gmake jansson curl e2fsprogs-libuuid
   clone_script: |

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -18,30 +18,6 @@ jobs:
   # GitHub Currently only supports running directly on Ubuntu,
   # for any other Linux we need to use a container.
 
-  # CentOS 7 / glibc 2.17 / gcc 4.8.5
-  centos_7:
-    runs-on: ubuntu-latest
-
-    container:
-      image: centos:7
-
-    steps:
-      - name: Install tools/deps
-        run: |
-          yum -y install git gcc make jansson-devel libcurl-devel
-          git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
-          cd ${RUNNER_TEMP}/libmtdac/src
-          make
-          export LD_LIBRARY_PATH=`pwd`
-
-      - uses: actions/checkout@v2
-
-      - name: make
-        # Fudge the version seeing as we don't actually have a git
-        # repository here due to needing git 2.18+. The version
-        # number is not actually important to just test the build.
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make GIT_VERSION=\\\"v0.0.0\\\" V=1
-
   # Rocky Linux 8 (RHEL clone) / glibc 2.28 / gcc 8.5.0
   rocky-linux-8:
     runs-on: ubuntu-latest
@@ -53,6 +29,7 @@ jobs:
       - name: Install tools/deps
         run: |
           yum -y install git gcc make jansson-devel libcurl-devel
+          git config --global --add safe.directory /__w/mtd-cli/mtd-cli
           git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
           cd ${RUNNER_TEMP}/libmtdac/src
           make
@@ -65,18 +42,19 @@ jobs:
       - name: make
         run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make V=1
 
-  # Debian 11 / glibc 2.31 / gcc 10.2
-  debian_11:
+  # Debian 12 / glibc 2.36 / gcc 12
+  debian_12:
     runs-on: ubuntu-latest
 
     container:
-      image: debian:11
+      image: debian:12
 
     steps:
       - name: Install deps
         run: |
           apt-get -y update
           apt-get -y install git gcc make libjansson-dev libcurl4-openssl-dev
+          git config --global --add safe.directory /__w/mtd-cli/mtd-cli
           git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
           cd ${RUNNER_TEMP}/libmtdac/src
           make
@@ -94,12 +72,13 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: alpine
+      image: alpine:edge
 
     steps:
       - name: Install tools/deps
         run: |
           apk add build-base linux-headers git jansson-dev curl-dev
+          git config --global --add safe.directory /__w/mtd-cli/mtd-cli
           git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
           cd ${RUNNER_TEMP}/libmtdac/src
           make
@@ -112,15 +91,15 @@ jobs:
       - name: make
         run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make V=1
 
-  # Fedora 34 / glibc 2.33 / gcc 11.2 / clang 12.0 
-  # Fedora 35 / glibc 2.34 / gcc 11.2 / clang 13.0
+  # Fedora 41 / glibc 2.40 / gcc 14 / clang 19
+  # Fedora 42 / glibc 2.41 / gcc 15 / clang 20
   fedora:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'fedora:34', 'fedora:35' ]
+        os: [ 'fedora:41', 'fedora:42' ]
         compiler: [ 'gcc', 'clang' ]
 
     container:
@@ -130,6 +109,7 @@ jobs:
       - name: Install tools/deps
         run: |
           dnf -y install git ${{ matrix.compiler }} make jansson-devel libcurl-devel
+          git config --global --add safe.directory /__w/mtd-cli/mtd-cli
           git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
           cd ${RUNNER_TEMP}/libmtdac/src
           make CC=${{ matrix.compiler }}


### PR DESCRIPTION
Remove CentOS 7

Update to Debian 12, Fedora 41 & 42, Alpine Edge, and FreeBSD 14