### PR TITLE
ci: Updates

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -67,17 +67,22 @@ jobs:
       - name: make
         run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make V=1
 
-  # Alpine Linux with musl libc and GCC
+  # Alpine Linux with musl libc and GCC & Clang
   alpine:
     runs-on: ubuntu-latest
 
     container:
       image: alpine:edge
 
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ 'gcc', 'clang' ]
+
     steps:
       - name: Install tools/deps
         run: |
-          apk add build-base linux-headers git jansson-dev curl-dev
+          apk add build-base linux-headers ${{ matrix.compiler }} git jansson-dev curl-dev
           git config --global --add safe.directory /__w/mtd-cli/mtd-cli
           git clone https://github.com/ac000/libmtdac.git ${RUNNER_TEMP}/libmtdac
           cd ${RUNNER_TEMP}/libmtdac/src
@@ -88,22 +93,20 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: make
-        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make V=1
+      - name: make CC=${{ matrix.compiler }}
+        run: CFLAGS="-I${RUNNER_TEMP}/libmtdac/include -Werror" LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make CC=${{ matrix.compiler }} V=1
 
-  # Fedora 41 / glibc 2.40 / gcc 14 / clang 19
   # Fedora 42 / glibc 2.41 / gcc 15 / clang 20
   fedora:
     runs-on: ubuntu-latest
 
+    container:
+      image: fedora:latest
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'fedora:41', 'fedora:42' ]
         compiler: [ 'gcc', 'clang' ]
-
-    container:
-      image: ${{ matrix.os }}
 
     steps:
       - name: Install tools/deps


### PR DESCRIPTION
Remove Fedora 41, just current Fedora is really enough.

Add an Alpine builder with Clang.