### PR TITLE
ci: codeql: Update to V3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
           cd $GITHUB_WORKSPACE
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -54,6 +54,6 @@ jobs:
         run: CFLAGS=-I${RUNNER_TEMP}/libmtdac/include LDFLAGS=-L${RUNNER_TEMP}/libmtdac/src make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Link: <https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/>