### PR TITLE
Do per API initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The first argument specifies the API to interface with
 
   * **init-nino** is for storing the National Insurance Number in the nino.json file.
 
+Each of the above init functions (except *init-nino*) takes an argument of
+either *itsa* or *vat* depending on which API is to be initialised.
+
 
 # Supported API endpoints
 


### PR DESCRIPTION
Rather than trying to initialise *both* ITSA and VAT, have the init, init-oauth & init-creds commands take an argument of either "itsa" or "vat" to specify which API to initialise.