### PR TITLE
Allow to optionally log to a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,30 @@ This can be used to override the default log level (MTD_OPT_LOG_ERR).
 
 Currently recognised values are; *debug* & *info*
 
+This can take two extra optional parameters; a file path and an *fopen(2)*
+mode.
+
+E.g.
+
+::
+
+    $ MTD_CLI_OPT_LOG_LEVEL=debug:/tmp/mtd-cli.log mtd-cli ...``
+
+and
+
+::
+
+    $ MTD_CLI_OPT_LOG_LEVEL=debug:/tmp/mtd-cli.log+a mtd-cli ...``
+
+The first will cause all log messages (except *MTD_LOG_ERROR*) to be written
+to the file */tmp/mtd-cli.log*.
+
+The second will do the above but will *append* messages to the file (creating
+it if it doesn't exist).
+
+This of course does mean that the file name should not contain either a
+``:`` or a ``+``.
+
 **MTD_CLI_OPT_NO_FPH_HDRS**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/mtd-cli.c
+++ b/src/mtd-cli.c
@@ -374,6 +374,31 @@ static const char *conf_dir(char *path)
 	return path;
 }
 
+static const FILE *set_log_fp(const char *log_level)
+{
+	char *ptr;
+	char *ptrm;
+	const char *mode = "we";
+
+	if (!log_level || !strchr(log_level, ':'))
+		return NULL;
+
+	ptr = strchr(log_level, ':');
+	ptr++;
+
+	ptrm = strchr(log_level, '+');
+	if (!ptrm)
+		goto out;
+
+	*(ptrm++) = '\0';
+
+	if (*ptrm != '\0' && *ptrm == 'a')
+		mode = "ae";
+
+out:
+	return fopen(ptr, mode);
+}
+
 int main(int argc, char *argv[])
 {
 	int err;
@@ -390,7 +415,8 @@ int main(int argc, char *argv[])
 	const struct mtd_cfg cfg = {
 		.config_dir = conf_dir(conf_dir_path),
 		.fph_ops = &fph_ops,
-		.extra_hdrs = hdrs
+		.extra_hdrs = hdrs,
+		.log_fp = set_log_fp(log_level)
 	};
 
 	if (argc == 1) {


### PR DESCRIPTION
E.g.

  $ MTD_CLI_OPT_LOG_LEVEL=debug:/tmp/mtd-cli.log mtd-cli ...

or

  $ MTD_CLI_OPT_LOG_LEVEL=debug:/tmp/mtd-cli.log+a mtd-cli ...

The +a says to append messages to the file rather than overwriting it.